### PR TITLE
Make guides DRY

### DIFF
--- a/docs/_includes/guides.md
+++ b/docs/_includes/guides.md
@@ -2,14 +2,14 @@
 
 Helm:
 
-* [Installation](/guides/helm)
+- [Installation](/guides/helm)
 
 Production:
 
-* [Google Cloud](/guides/google-cloud)
-* [AWS](/guides/aws)
+- [Google Cloud](/guides/google-cloud)
+- [AWS](/guides/aws)
 
 Dev:
 
-* [Docker for Mac](/guides/docker-for-mac)
-* [Minikube](/guides/minikube)
+- [Docker for Mac](/guides/docker-for-mac)
+- [Minikube](/guides/minikube)

--- a/docs/_includes/guides.md
+++ b/docs/_includes/guides.md
@@ -1,5 +1,7 @@
 ## Guides
+
 Helm:
+
 * [Installation](/guides/helm)
 
 Production:

--- a/docs/_includes/guides.md
+++ b/docs/_includes/guides.md
@@ -1,0 +1,13 @@
+## Guides
+Helm:
+* [Installation](/guides/helm)
+
+Production:
+
+* [Google Cloud](/guides/google-cloud)
+* [AWS](/guides/aws)
+
+Dev:
+
+* [Docker for Mac](/guides/docker-for-mac)
+* [Minikube](/guides/minikube)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,17 +17,7 @@ by emailing us at [humans@astronomer.io](mailto:humans@astronomer.io).
 We're super easy to deal with; we'll make
 sure the price is right for your value.
 
-## Guides
-
-Production:
-
-* [Google Cloud](/guides/google-cloud)
-
-Dev:
-
-* [Docker for Mac](/guides/docker-for-mac)
-* [Minikube](/guides/minikube)
-
+{% include guides.md %}
 
 ## Modules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ order: 1
 ---
 
 ## Overview
+
 Astronomer Enterprise Edition allows your to deploy
 Astronomer Modules to Kubernetes.
 
@@ -21,18 +22,11 @@ sure the price is right for your value.
 
 ## Modules
 
-1. [Clickstream](/clickstream) — Docker images for an
-[Analytics.js](https://github.com/segmentio/analytics.js)-based
-clickstream system with server-side event processing. Includes a
-Go Event API, Apache Kafka, Go Event Router, and server-side
-integration workers that push data off to ~50 common APIs.
-
-2. [Airflow](/airflow) — Docker images for
-[Apache Airflow](https://airflow.apache.org/)-based ETL system
-that is pre-configured to run Airflow, Celery, Flower, StatsD,
-Prometheus, and Grafana.
+1. [Clickstream](/clickstream) — Docker images for an [Analytics.js](https://github.com/segmentio/analytics.js)-based clickstream system with server-side event processing. Includes a Go Event API, Apache Kafka, Go Event Router, and server-side integration workers that push data off to ~50 common APIs.
+1. [Airflow](/airflow) — Docker images for [Apache Airflow](https://airflow.apache.org/)-based ETL system that is pre-configured to run Airflow, Celery, Flower, StatsD, Prometheus, and Grafana.
 
 ## Building the Documentation
+
 Documentation is built on jekyll and currently hosted on GitHub
 pages. To run the docs site locally:
 

--- a/docs/pages/guides.md
+++ b/docs/pages/guides.md
@@ -5,16 +5,4 @@ permalink: /guides/
 order: 1
 ---
 
-## Guides
-Helm:
-* [Installation](/guides/helm)
-
-Production:
-
-* [Google Cloud](/guides/google-cloud)
-* [AWS](/guides/aws)
-
-Dev:
-
-* [Docker for Mac](/guides/docker-for-mac)
-* [Minikube](/guides/minikube)
+{% include guides.md %}


### PR DESCRIPTION
The guides list is used in two places so let's pull from an include instead of duplicating.
