### PR TITLE
CLI install notes

### DIFF
--- a/docs/pages/guides/migrating-dags.md
+++ b/docs/pages/guides/migrating-dags.md
@@ -9,15 +9,14 @@ hide: true
 
 ## Install Astro CLI
 
-> Note: we currently have two CLIs called `astro`, one for our cloud
-edition and this new CLI for enterprise edition. We're working to merge
-them both, for for the time being, the enterprise CLI is called
-`astro-cli`. If you're not using our cloud edition CLI, you can alias
-`astro-cli` to `astro`.
 
 * <https://github.com/astronomerio/astro-cli>
 * `go get github.com/astronomerio/astro-cli`
 * `alias astro=astro-cli` in your `.bash_profile`
+> Note: we currently have two CLIs called `astro`, one for our Cloud Edition and
+this new CLI for Enterprise Edition. We're working to merge them, but for the
+time being, the Enterprise CLI is called `astro-cli`. If you're not using our
+Cloud Edition CLI, you can alias `astro-cli` to `astro`.
 
 ## Choose some DAGs + verify they run locally
 

--- a/docs/pages/guides/migrating-dags.md
+++ b/docs/pages/guides/migrating-dags.md
@@ -9,14 +9,13 @@ hide: true
 
 ## Install Astro CLI
 
-
-* <https://github.com/astronomerio/astro-cli>
-* `go get github.com/astronomerio/astro-cli`
-* `alias astro=astro-cli` in your `.bash_profile`
 > Note: we currently have two CLIs called `astro`, one for our Cloud Edition and
 this new CLI for Enterprise Edition. We're working to merge them, but for the
 time being, the Enterprise CLI is called `astro-cli`. If you're not using our
 Cloud Edition CLI, you can alias `astro-cli` to `astro`.
+>
+> See the README in <https://github.com/astronomerio/astro-cli> for complete
+installation instructions.
 
 ## Choose some DAGs + verify they run locally
 


### PR DESCRIPTION
I wrote a pretty nice readme for the new astro-cli repo that covers setup, quickstart including the bash alias workaround, and hacking on the CLI.  I think it makes sense to link out to that content from here.

Reference - https://github.com/astronomerio/astro-cli/blob/master/README.md