### PR TITLE
Add Astronomer Upgrade guide

### DIFF
--- a/docs/_includes/guides.md
+++ b/docs/_includes/guides.md
@@ -10,6 +10,7 @@ Production:
 
 - [Google Cloud Platform](/guides/google-cloud)
 - [AWS](/guides/aws)
+- [Upgrade Astronomer](/guides/upgrade)
 
 Dev:
 

--- a/docs/pages/guides/google-cloud.md
+++ b/docs/pages/guides/google-cloud.md
@@ -203,11 +203,7 @@ If you recieve any weird errors from helm, you may need to give Tiller access to
 
 ## Upgrade
 
-To roll out an upgrade to an existing release:
-
-```bash
-helm upgrade -f config.yaml --namespace astronomer <release name> .
-```
+To upgrade an Astronomer install, please see [Upgrade Astronomer](/guides/upgrade/).
 
 ## Test
 

--- a/docs/pages/guides/upgrade.md
+++ b/docs/pages/guides/upgrade.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Upgrade Astronomer
+permalink: /guides/upgrade/
+hide: true
+---
+
+## Upgrade Astronomer
+
+Once the Astronomer umbrella chart is installed, you may want to make config changes, or upgrade to a newer release.
+
+Helm makes it easy to update a Kubernetes cluster.
+
+Most updates can be installed by running:
+
+```bash
+cd astronomer-ee
+helm upgrade -f config.yaml --namespace astronomer <release name> .
+```
+
+There are some cases where Helm cannot do an automatic upgrade which can be resolved by doing a fresh install.


### PR DESCRIPTION
It was mentioned to us that the instructions for upgrading Astronomer would be easier to find if they were more visible as opposed to being in the middle of the GCP setup guide.
