### PR TITLE
Break out build the docs instructions

### DIFF
--- a/docs/_includes/guides.md
+++ b/docs/_includes/guides.md
@@ -24,3 +24,7 @@ Usage:
 Customization:
 
 - [Configuring Airflow](/guides/configuring-airflow)
+
+Misc:
+
+- [Build the Docs](/guides/build-docs/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,20 +35,3 @@ allowfullscreen></iframe>
 
 1. [Clickstream](/clickstream) — Docker images for an [Analytics.js](https://github.com/segmentio/analytics.js){:target="_blank"}-based clickstream system with server-side event processing. Includes a Go Event API, Apache Kafka, Go Event Router, and server-side integration workers that push data off to ~50 common APIs.
 1. [Airflow](/airflow) — Docker images for [Apache Airflow](https://airflow.apache.org/){:target="_blank"}-based ETL system that is pre-configured to run Airflow, Celery, Flower, StatsD, Prometheus, and Grafana.
-
-## Building the Documentation
-
-Documentation is built on Jekyll and hosted on Google Cloud Storage.
-
-Build the docs site locally:
-
-```
-cd docs
-bundle install
-```
-
-Run it:
-
-```
-bundle exec jekyll serve
-```

--- a/docs/pages/guides/build-docs.md
+++ b/docs/pages/guides/build-docs.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Build the Docs
+permalink: /guides/build-docs/
+hide: true
+---
+
+## Build the Docs
+
+The documentation site is built on Jekyll and hosted on Google Cloud Storage.
+
+To build the docs site locally:
+
+```
+cd docs
+bundle install
+```
+
+Run it:
+
+```
+bundle exec jekyll serve
+```


### PR DESCRIPTION
Most users will just use our own docs site, so the instructions to building the docs site don't need to be on the front page.

Building the docs site is more useful to developers, contributors, and people inside a locked down network.